### PR TITLE
9.商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
 class ItemsController < ApplicationController
   # before_action :move_to_index, except: [:index]
-  before_action :authenticate_user!, only: [:new, :update, :edit, :update]
-  before_action :redirect_if_not_owner, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :set_item, only: [:show, :edit]
+  before_action :redirect_if_not_owner, only: [:edit, :update]
+
 
   def index
     @items = Item.order("created_at DESC")
@@ -47,7 +48,6 @@ class ItemsController < ApplicationController
 
   # 別の出品者の商品は見れない機能
   def redirect_if_not_owner
-    @item = Item.find(params[:id])
     unless @item.user_id == current_user.id
       redirect_to root_path, alert: "You are not authorized to edit this item."
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
-  before_action :authenticate_user!, only: :new
+  # before_action :move_to_index, except: [:index]
+  before_action :authenticate_user!, exept: [:show, :index]
   before_action :redirect_if_not_owner, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit]
 
   def index
     @items = Item.order("created_at DESC")
@@ -12,7 +13,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def create
@@ -25,7 +25,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
@@ -39,16 +38,12 @@ class ItemsController < ApplicationController
 
   private
 
-
   def item_params
     params.require(:item).permit(:name, :content, :price, :category_id, :status_id, :delivery_charge_id, :delivery_date_id, :prefecture_id, :image).merge(user_id: current_user.id)
   end
 
-  # サインインしていないとき、インデックスページしか見れない機能
-  def move_to_index
-    unless user_signed_in? 
-      redirect_to new_user_session_path
-    end
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   # 別の出品者の商品は見れない機能

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  # before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index]
   before_action :authenticate_user!, only: :new
   def index
     @items = Item.order("created_at DESC")
@@ -29,7 +29,7 @@ class ItemsController < ApplicationController
   def update
     item = Item.find(params[:id])
     if item.update(item_params)
-      redirect_to root_path
+      redirect_to item_path(item.id)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -43,9 +43,10 @@ class ItemsController < ApplicationController
   end
 
   # サインインしていないとき、インデックスページしか見れない機能
-  # def move_to_index
-  #   unless user_signed_in?
-  #     redirect_to action: :index
-  #   end
-  # end
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index]
   before_action :authenticate_user!, only: :new
+  before_action :redirect_if_not_owner, only: [:edit, :update]
+
   def index
     @items = Item.order("created_at DESC")
   end
@@ -27,8 +29,8 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    if item.update(item_params)
+    # item = Item.find(params[:id])
+    if @item.update(item_params)
       redirect_to item_path(item.id)
     else
       render :edit, status: :unprocessable_entity
@@ -44,8 +46,16 @@ class ItemsController < ApplicationController
 
   # サインインしていないとき、インデックスページしか見れない機能
   def move_to_index
-    unless user_signed_in?
+    unless user_signed_in? 
       redirect_to action: :index
+    end
+  end
+
+  # 別の出品者の商品は見れない機能
+  def redirect_if_not_owner
+    @item = Item.find(params[:id])
+    unless @item.user_id == current_user.id
+      redirect_to root_path, alert: "You are not authorized to edit this item."
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
   def update
     # item = Item.find(params[:id])
     if @item.update(item_params)
-      redirect_to item_path(item.id)
+      redirect_to item_path(@item.id)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,7 +47,7 @@ class ItemsController < ApplicationController
   # サインインしていないとき、インデックスページしか見れない機能
   def move_to_index
     unless user_signed_in? 
-      redirect_to action: :index
+      redirect_to new_user_session_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,19 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    if item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   # before_action :move_to_index, except: [:index]
-  before_action :authenticate_user!, exept: [:show, :index]
+  before_action :authenticate_user!, only: [:new, :update, :edit, :update]
   before_action :redirect_if_not_owner, only: [:edit, :update]
   before_action :set_item, only: [:show, :edit]
 
@@ -28,7 +28,6 @@ class ItemsController < ApplicationController
   end
 
   def update
-    # item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -11,9 +11,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: item_path(params[:id]), local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,8 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
 
+<script src="index.js"></script>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
@@ -52,12 +54,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +75,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_charge_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_charge_id, DeliveryCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_date_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_date_id, DeliveryDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -141,7 +143,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -12,7 +12,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @item, url: item_path(params[:id]), local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -143,7 +143,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path(params[:id]), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(params[:id]), local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :content, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_charge_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_date_id, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,7 +156,6 @@
       </li>
       <% end %>
 
-      <%# 商品がないときのダミー %>
       <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -179,7 +178,6 @@
 
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if user_signed_in? %>
       <%# unless @item.history.present? %>
         <% if user_signed_in? && current_user.id == @item.user_id %>
-          <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+          <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
           <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
         <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <% if user_signed_in? %>
       <%# unless @item.history.present? %>
-        <% if user_signed_in? && current_user.id == @item.user_id %>
+        <% if current_user.id == @item.user_id %>
           <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
           <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" if @item.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# if @item.history.present? %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
       <%# end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">


### PR DESCRIPTION
## プルリクエスト１回目
# what
商品情報を編集できるようにしました
・バリデーションに引っかかるとエラーが出ます。
・他のユーザーは編集ページにアクセスできないようにしています。
・他の細かな実装条件はissueの通りです。

# why
商品情報に入力ミスがあった際に修正できるようにするため。

## プルリクエストへ記載するgyazo
▽ ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/527674c3c0890df7cb51bb6c181429d9
▽ 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/6d5ce85deedf3886906f615e1beb8f46
 ▽入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/a6b185da90a1919363f6b7f2b1f0bc46
 ▽何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/616427262524bff76b7be1c70bf80139
 ▽ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/8a2caa57d186ddef013c9611cd858053
 ▽ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
なし
▽ ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/c2789458dffe7c2be4f04f70d34cde08
 ▽商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/37efe2e921606902aa10e301d3d7bab6